### PR TITLE
Fix CPANTS warning about missing perl version

### DIFF
--- a/style/Makefile.PL
+++ b/style/Makefile.PL
@@ -16,6 +16,7 @@ WriteMakefile(
         'CSS::Tiny' => 0,
         'Template::Flute' => 0.0081,
     },
+    MIN_PERL_VERSION => '5.008001',
     META_MERGE        => {
         resources => {
             repository  => 'https://github.com/racke/Template-Flute.git',


### PR DESCRIPTION
Added the MIN_PERL_VERSION parameter which will be propagated to the
meta data files.

This is part of the CPAN Pull Request Challenge, where I got
Template::Flute::Style::CSS as my April assignment.