### PR TITLE
Fix links to repository and bugtracker

### DIFF
--- a/style/Makefile.PL
+++ b/style/Makefile.PL
@@ -18,8 +18,8 @@ WriteMakefile(
     },
     META_MERGE        => {
         resources => {
-            repository  => 'https://github.com/racke/Template-Flute.git',
-            bugtracker  => 'https://github.com/racke/Template-Flute/issues',
+            repository  => 'https://github.com/racke/Template-Flute-Style-CSS',
+            bugtracker  => 'https://github.com/racke/Template-Flute-Style-CSS/issues',
         },
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },


### PR DESCRIPTION
Links were pointing to the Template::Flute repository and bugtracker,
which meant that links on (meta)cpan would be wrong.

This is part of the CPAN Pull Request Challenge, where I got
Template::Flute::Style::CSS as my April assignment.